### PR TITLE
Fix PHP deprecated warnings

### DIFF
--- a/code/functions.php
+++ b/code/functions.php
@@ -255,7 +255,7 @@ function suffusion_setup_standard_actions_and_filters() {
 		add_filter('excerpt_more', 'suffusion_excerpt_more_replace');
 		add_filter('the_excerpt', 'suffusion_excerpt_more_append');
 
-		add_filter('comment_reply_link', 'suffusion_hide_reply_link_for_pings', 10, 4);
+		add_filter('comment_reply_link', 'suffusion_hide_reply_link_for_pings', 10, 3);
 		add_filter('get_comments_number', 'suffusion_filter_trk_ping_from_count');
 		add_filter('get_comments_pagenum_link', 'suffusion_append_comment_type');
 

--- a/code/functions/filters.php
+++ b/code/functions/filters.php
@@ -45,7 +45,7 @@ function suffusion_pages_link($content) {
 	return $content;
 }
 
-function suffusion_hide_reply_link_for_pings($link, $custom_options = array(), $current_comment, $current_post) {
+function suffusion_hide_reply_link_for_pings($link, $current_comment, $current_post) {
 	global $suf_show_hide_reply_link_for_pings;
 	if ($suf_show_hide_reply_link_for_pings != "allow") {
 		if (($current_comment->comment_type != "") && ($current_comment->comment_type != "comment")) {

--- a/code/library/suffusion-walkers.php
+++ b/code/library/suffusion-walkers.php
@@ -24,7 +24,7 @@ class Suffusion_MM_Walker extends Walker_Nav_Menu {
 		parent::start_el($output, $item, $depth, $args, $id = 0);
 	}
 
-    function display_element($element, &$children_elements, $max_depth, $depth, $args, &$output) {
+    	function display_element($element, &$children_elements, $max_depth, $depth, $args, &$output) {
 		// For nested levels we want to check if the parent is mega-menu enabled. If so, we shouldn't print the children.
 		if ($depth == 1) {
 			$parent_id = $element->menu_item_parent;

--- a/code/library/suffusion-walkers.php
+++ b/code/library/suffusion-walkers.php
@@ -24,7 +24,7 @@ class Suffusion_MM_Walker extends Walker_Nav_Menu {
 		parent::start_el($output, $item, $depth, $args, $id = 0);
 	}
 
-	function display_element($element, &$children_elements, $max_depth, $depth = 0, $args, &$output) {
+    function display_element($element, &$children_elements, $max_depth, $depth, $args, &$output) {
 		// For nested levels we want to check if the parent is mega-menu enabled. If so, we shouldn't print the children.
 		if ($depth == 1) {
 			$parent_id = $element->menu_item_parent;

--- a/code/library/suffusion-walkers.php
+++ b/code/library/suffusion-walkers.php
@@ -24,7 +24,7 @@ class Suffusion_MM_Walker extends Walker_Nav_Menu {
 		parent::start_el($output, $item, $depth, $args, $id = 0);
 	}
 
-    	function display_element($element, &$children_elements, $max_depth, $depth, $args, &$output) {
+	function display_element($element, &$children_elements, $max_depth, $depth, $args, &$output) {
 		// For nested levels we want to check if the parent is mega-menu enabled. If so, we shouldn't print the children.
 		if ($depth == 1) {
 			$parent_id = $element->menu_item_parent;


### PR DESCRIPTION
Fixes the following PHP 8 messages in `debug.log`:

```
[17-Nov-2023 17:56:40 UTC] PHP Deprecated:  Required parameter $args follows optional parameter $depth in /mnt/web101/d2/95/5228195/htdocs/lio/wp-content/themes/suffusion/library/suffusion-walkers.php on line 27
[17-Nov-2023 17:56:40 UTC] PHP Deprecated:  Required parameter $output follows optional parameter $depth in /mnt/web101/d2/95/5228195/htdocs/lio/wp-content/themes/suffusion/library/suffusion-walkers.php on line 27

[17-Nov-2023 17:23:12 UTC] PHP Deprecated:  Required parameter $current_comment follows optional parameter $custom_options in /mnt/web101/d2/95/5228195/htdocs/lio/wp-content/themes/suffusion/functions/filters.php on line 48
[17-Nov-2023 17:23:12 UTC] PHP Deprecated:  Required parameter $current_post follows optional parameter $custom_options in /mnt/web101/d2/95/5228195/htdocs/lio/wp-content/themes/suffusion/functions/filters.php on line 48
```

Closes #37 