### PR TITLE
Improve PHP 8.x compatibility

### DIFF
--- a/code/admin/suffusion-options-page.php
+++ b/code/admin/suffusion-options-page.php
@@ -166,6 +166,8 @@ function suffusion_save_css_to_file($custom_css = array()) {
 			echo "<div class='error'><p>Failed to save file $filename. Please check your folder permissions.</p></div>";
 		}
 	}
+
+	return true;
 }
 
 /**

--- a/code/admin/theme-options-layouts.php
+++ b/code/admin/theme-options-layouts.php
@@ -1556,7 +1556,6 @@ $suffusion_layouts_options = array(
 		"id" => "suf_tile_layout_bylines_post_date",
 		"grouping" => "tile-layout-bylines",
 		"parent" => "excerpt-settings",
-		"grouping" => "layout-tiles",
 		"type" => "radio",
 		"options" => array("show" => "Show", "hide" => "Hide"),
 		"std" => "show"),

--- a/code/admin/theme-options-renderer.php
+++ b/code/admin/theme-options-renderer.php
@@ -1444,7 +1444,7 @@ class Suffusion_Options_Renderer {
 	function initialize_settings($structure = null) {
 		$options = $this->options;
 		if (is_null($structure)) {
-			$structure = $this->get_option_structure($options);
+			$structure = $this->get_option_structure();
 		}
 
 		foreach ($structure as $option_entity) {
@@ -1697,7 +1697,7 @@ class Suffusion_Options_Renderer {
 	 * the user is migrating from 3.0.2 or lower.
 	 *
 	 * @param  $options
-	 * @return void
+	 * @return array
 	 */
 	function migrate_from_v302($options) {
 		global $suffusion_inbuilt_options;

--- a/code/featured-posts.php
+++ b/code/featured-posts.php
@@ -83,7 +83,7 @@ function suffusion_display_featured_posts($echo = true) {
     $featured_pages = suffusion_get_allowed_pages('suf_featured_selected_pages');
 	$count_so_far = 0;
 	if (is_array($stickies) && count($stickies) > 0 && $suf_featured_allow_sticky == "show") {
-		$sticky_query = new WP_query(array('post__in' => $stickies));
+		$sticky_query = new WP_Query(array('post__in' => $stickies));
 		$count_so_far += $sticky_query->post_count;
 	}
 
@@ -94,7 +94,7 @@ function suffusion_display_featured_posts($echo = true) {
 		else {
 			$number_of_latest_posts = $suf_featured_num_latest_posts;
 		}
-		$latest_query = new WP_query(array('post__not_in' => $stickies, 'posts_per_page' => $number_of_latest_posts, 'order' => 'DESC', 'ignore_sticky_posts' => 1));
+		$latest_query = new WP_Query(array('post__not_in' => $stickies, 'posts_per_page' => $number_of_latest_posts, 'order' => 'DESC', 'ignore_sticky_posts' => 1));
 		$count_so_far += $latest_query->post_count;
     }
 
@@ -156,14 +156,14 @@ function suffusion_display_featured_posts($echo = true) {
         foreach ($featured_pages as $featured_page) {
             $query_pages[count($query_pages)] = $featured_page->ID;
         }
-        $page_query = new WP_query(array('post_type' => 'page', 'post__in' => $query_pages, 'posts_per_page' => $suf_featured_num_posts, 'ignore_sticky_posts' => 1, 'orderby' => 'menu_order', 'order' => 'ASC'));
+        $page_query = new WP_Query(array('post_type' => 'page', 'post__in' => $query_pages, 'posts_per_page' => $suf_featured_num_posts, 'ignore_sticky_posts' => 1, 'orderby' => 'menu_order', 'order' => 'ASC'));
 		$count_so_far += $page_query->post_count;
     }
 
 	if (isset($suf_featured_selected_posts) && trim($suf_featured_selected_posts) != '' && $count_so_far < $suf_featured_num_posts) {
 		$trim_featured_posts = str_replace(' ', '', $suf_featured_selected_posts);
 		$query_posts = explode(',', $trim_featured_posts);
-		$post_query = new WP_query(array('post_type' => 'post', 'post__in' => $query_posts, 'posts_per_page' => $suf_featured_num_posts, 'ignore_sticky_posts' => 1));
+		$post_query = new WP_Query(array('post_type' => 'post', 'post__in' => $query_posts, 'posts_per_page' => $suf_featured_num_posts, 'ignore_sticky_posts' => 1));
 		$count_so_far += $post_query->post_count;
 	}
 

--- a/code/functions.php
+++ b/code/functions.php
@@ -827,7 +827,7 @@ function suffusion_flatten_option($option) {
 /**
  * Returns an indented array of pages, based on parent and child pages. This is used in the admin menus.
  *
- * @return array
+ * @return array|null
  */
 function suffusion_get_formatted_page_array() {
 	global $suffusion_pages_array;

--- a/code/functions/admin.php
+++ b/code/functions/admin.php
@@ -568,7 +568,7 @@ function suffusion_admin_upload_file() {
 		$data = $_POST['data'];
 		$image_id = substr($data, 6);
 		if (isset($suffusion_options_renderer) && isset($suffusion_options_renderer->options)) {
-			if (isset($suffusion_options_renderer->options[$image_id])) unset($this->options[$image_id]);
+			if (isset($suffusion_options_renderer->options[$image_id])) unset($suffusion_options_renderer->options[$image_id]);
 		}
 	}
 	die();

--- a/code/functions/magazine-functions.php
+++ b/code/functions/magazine-functions.php
@@ -44,7 +44,7 @@ function suffusion_get_headlines() {
 			$query_cats[] = $headline_category->cat_ID;
 		}
 		$query_posts = implode(",", array_values($query_cats));
-		$cat_query = new WP_query(array('cat' => $query_posts, 'post__not_in' => $solos));
+		$cat_query = new WP_Query(array('cat' => $query_posts, 'post__not_in' => $solos));
 	}
 
 	if (isset($cat_query->posts) && is_array($cat_query->posts)) {
@@ -91,7 +91,7 @@ function suffusion_get_mag_section_queries($args = array()) {
 		}
 	}
 	if (count($solos) > 0) {
-		$solo_query = new WP_query(array('post__in' => $solos, 'ignore_sticky_posts' => 1));
+		$solo_query = new WP_Query(array('post__in' => $solos, 'ignore_sticky_posts' => 1));
 		$queries[] = $solo_query;
 	}
 
@@ -104,7 +104,7 @@ function suffusion_get_mag_section_queries($args = array()) {
 				$query_cats[] = $category->cat_ID;
 			}
 			$query_posts = implode(",", array_values($query_cats));
-			$cat_query = new WP_query(array('cat' => $query_posts, 'post__not_in' => $solos, 'posts_per_page' => (int)$suf_mag_total_excerpts));
+			$cat_query = new WP_Query(array('cat' => $query_posts, 'post__not_in' => $solos, 'posts_per_page' => (int)$suf_mag_total_excerpts));
 			$queries[] = $cat_query;
 		}
 	}

--- a/code/magazine.php
+++ b/code/magazine.php
@@ -232,7 +232,7 @@ foreach ($sequence as $entity) {
 							$cat_args['orderby'] = 'order';
 						}
 
-						$query = new WP_query($cat_args);
+						$query = new WP_Query($cat_args);
 						if (isset($query->posts) && is_array($query->posts) && count($query->posts) > 0) {
 							$ul_class = '';
 							$li_class = '';

--- a/code/suffusion-featured-posts.php
+++ b/code/suffusion-featured-posts.php
@@ -532,24 +532,24 @@ class Suffusion_Featured_Posts extends WP_Widget {
 
 		$stickies = get_option('sticky_posts');
 		if (is_array($stickies) && count($stickies) > 0 && $show_sticky) {
-			$sticky_query = new WP_query(array('post__in' => $stickies));
+			$sticky_query = new WP_Query(array('post__in' => $stickies));
 		}
 		if ($latest_posts) {
-			$latest_query = new WP_query(array('post__not_in' => $stickies, 'posts_per_page' => $number_of_latest_posts, 'order' => 'DESC', 'ignore_sticky_posts' => 1));
+			$latest_query = new WP_Query(array('post__not_in' => $stickies, 'posts_per_page' => $number_of_latest_posts, 'order' => 'DESC', 'ignore_sticky_posts' => 1));
         }
 		if ($featured_categories && trim($featured_categories) != '') {
-			$cat_query = new WP_query(array('cat' => $featured_categories, 'post__not_in' => $stickies, 'posts_per_page' => $number_of_posts));
+			$cat_query = new WP_Query(array('cat' => $featured_categories, 'post__not_in' => $stickies, 'posts_per_page' => $number_of_posts));
 		}
 		if ($featured_posts && trim($featured_posts) != '') {
 			$query_posts = explode(',', $featured_posts);
 			if ($query_posts) {
-				$post_query = new WP_query(array('post_type' => 'post', 'post__in' => $query_posts, 'posts_per_page' => $number_of_posts, 'ignore_sticky_posts' => 1));
+				$post_query = new WP_Query(array('post_type' => 'post', 'post__in' => $query_posts, 'posts_per_page' => $number_of_posts, 'ignore_sticky_posts' => 1));
 			}
 		}
 		if ($featured_pages && trim($featured_pages) != '') {
 			$query_pages = explode(',', $featured_pages);
 			if ($query_pages) {
-				$page_query = new WP_query(array('post_type' => 'page', 'post__in' => $query_pages, 'posts_per_page' => $number_of_posts, 'ignore_sticky_posts' => 1));
+				$page_query = new WP_Query(array('post_type' => 'page', 'post__in' => $query_pages, 'posts_per_page' => $number_of_posts, 'ignore_sticky_posts' => 1));
 			}
 		}
 

--- a/code/theme-options-renderer.php
+++ b/code/theme-options-renderer.php
@@ -1444,7 +1444,7 @@ class Suffusion_Options_Renderer {
 	function initialize_settings($structure = null) {
 		$options = $this->options;
 		if (is_null($structure)) {
-			$structure = $this->get_option_structure($options);
+			$structure = $this->get_option_structure();
 		}
 
 		foreach ($structure as $option_entity) {
@@ -1697,7 +1697,7 @@ class Suffusion_Options_Renderer {
 	 * the user is migrating from 3.0.2 or lower.
 	 *
 	 * @param  $options
-	 * @return void
+	 * @return array
 	 */
 	function migrate_from_v302($options) {
 		global $suffusion_inbuilt_options;

--- a/code/widgets/suffusion-featured-posts.php
+++ b/code/widgets/suffusion-featured-posts.php
@@ -532,24 +532,24 @@ class Suffusion_Featured_Posts extends WP_Widget {
 
 		$stickies = get_option('sticky_posts');
 		if (is_array($stickies) && count($stickies) > 0 && $show_sticky) {
-			$sticky_query = new WP_query(array('post__in' => $stickies));
+			$sticky_query = new WP_Query(array('post__in' => $stickies));
 		}
 		if ($latest_posts) {
-			$latest_query = new WP_query(array('post__not_in' => $stickies, 'posts_per_page' => $number_of_latest_posts, 'order' => 'DESC', 'ignore_sticky_posts' => 1));
+			$latest_query = new WP_Query(array('post__not_in' => $stickies, 'posts_per_page' => $number_of_latest_posts, 'order' => 'DESC', 'ignore_sticky_posts' => 1));
         }
 		if ($featured_categories && trim($featured_categories) != '') {
-			$cat_query = new WP_query(array('cat' => $featured_categories, 'post__not_in' => $stickies, 'posts_per_page' => $number_of_posts));
+			$cat_query = new WP_Query(array('cat' => $featured_categories, 'post__not_in' => $stickies, 'posts_per_page' => $number_of_posts));
 		}
 		if ($featured_posts && trim($featured_posts) != '') {
 			$query_posts = explode(',', $featured_posts);
 			if ($query_posts) {
-				$post_query = new WP_query(array('post_type' => 'post', 'post__in' => $query_posts, 'posts_per_page' => $number_of_posts, 'ignore_sticky_posts' => 1));
+				$post_query = new WP_Query(array('post_type' => 'post', 'post__in' => $query_posts, 'posts_per_page' => $number_of_posts, 'ignore_sticky_posts' => 1));
 			}
 		}
 		if ($featured_pages && trim($featured_pages) != '') {
 			$query_pages = explode(',', $featured_pages);
 			if ($query_pages) {
-				$page_query = new WP_query(array('post_type' => 'page', 'post__in' => $query_pages, 'posts_per_page' => $number_of_posts, 'ignore_sticky_posts' => 1));
+				$page_query = new WP_Query(array('post_type' => 'page', 'post__in' => $query_pages, 'posts_per_page' => $number_of_posts, 'ignore_sticky_posts' => 1));
 			}
 		}
 

--- a/code/widgets/suffusion-query-posts.php
+++ b/code/widgets/suffusion-query-posts.php
@@ -141,7 +141,7 @@ class Suffusion_Category_Posts extends WP_Widget {
 			$query_args['post_type'] = 'any';
 		}
 
-		$query = new WP_query($query_args);
+		$query = new WP_Query($query_args);
 
 		if (isset($query->posts) && is_array($query->posts) && count($query->posts) > 0 && !($separate_widgets && ($post_style == 'thumbnail-full' || $post_style == 'thumbnail-excerpt'))) {
             if ($post_style == 'magazine') {


### PR DESCRIPTION
Fix some PHP IntelliSense warnings:
- Parameter types
- Missing return values
- Superfluous parameters
- Double array entries
- Change `WP_query` to [`WP_Query`](https://developer.wordpress.org/reference/classes/wp_query/)


