### PR TITLE
Fix PHP warning when counting tags

### DIFF
--- a/code/widgets/suffusion-query-posts.php
+++ b/code/widgets/suffusion-query-posts.php
@@ -110,7 +110,8 @@ class Suffusion_Category_Posts extends WP_Widget {
 
 		if (trim($tags) != '') {
 			$solo_tags = preg_replace('/\s\s+/', ' ', $tags);
-			if (count($solo_tags) > 0) {
+			$solo_tags = explode(',', $solo_tags);
+			if (count(value: $solo_tags) > 0) {
 				$query_args['tag'] = $solo_tags;
 			}
 		}

--- a/code/widgets/suffusion-query-posts.php
+++ b/code/widgets/suffusion-query-posts.php
@@ -111,7 +111,7 @@ class Suffusion_Category_Posts extends WP_Widget {
 		if (trim($tags) != '') {
 			$solo_tags = preg_replace('/\s\s+/', ' ', $tags);
 			$solo_tags = explode(',', $solo_tags);
-			if (count(value: $solo_tags) > 0) {
+			if (count($solo_tags) > 0) {
 				$query_args['tag'] = $solo_tags;
 			}
 		}


### PR DESCRIPTION
Fix the following warning:

```
PHP Warning: count(): Parameter must be an array or an object that implements Countable in /home/........./public_html/wp-content/themes/suffusion/widgets/suffusion-query-posts.php on line 113
```

Closes #90 