### PR TITLE
Fix PHP warning when using excerpts

### DIFF
--- a/code/functions/filters.php
+++ b/code/functions/filters.php
@@ -207,7 +207,7 @@ function suffusion_excerpt_length_cat_block($length) {
 
 function suffusion_excerpt_more_replace($more) {
 	global $post, $suf_excerpt_read_more_style, $suf_excerpt_custom_more_text;
-	if ($suf_excerpt_read_more_style == 'append' || !isset($post->ID)) {
+	if ($suf_excerpt_read_more_style == 'append' || !isset($post)) {
 		return '';
 	}
 

--- a/code/functions/filters.php
+++ b/code/functions/filters.php
@@ -207,7 +207,7 @@ function suffusion_excerpt_length_cat_block($length) {
 
 function suffusion_excerpt_more_replace($more) {
 	global $post, $suf_excerpt_read_more_style, $suf_excerpt_custom_more_text;
-	if ($suf_excerpt_read_more_style == 'append') {
+	if ($suf_excerpt_read_more_style == 'append' || !isset($post->ID)) {
 		return '';
 	}
 
@@ -218,7 +218,7 @@ function suffusion_excerpt_more_replace($more) {
 
 function suffusion_excerpt_more_append($output) {
 	global $post, $suf_excerpt_read_more_style, $suf_excerpt_custom_more_text;
-	if ($suf_excerpt_read_more_style == 'replace') {
+	if ($suf_excerpt_read_more_style == 'replace' || !isset($post)) {
 		return $output;
 	}
 	$stripped = stripslashes($suf_excerpt_custom_more_text);


### PR DESCRIPTION
Fixes `PHP Warning:  Attempt to read property "ID" on null in /wordpress/wp-content/themes/suffusion/functions/filters.php on line 216`

This warning can happen when excerpts are used with Suffusion.